### PR TITLE
Update Android Installation instructions

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -4,7 +4,10 @@
 
 [Download the latest version on Google Play.](https://play.google.com/store/apps/details?id=com.mapeo&hl=en_US)
 
-[You can also download as an APK](https://digital-democracy.org/mapeo/latest/android) and load manually on the phone
+[You can also download as an APK](https://digital-democracy.org/mapeo/latest/android) and load manually on the phone. Please note that to install Android application APK from outside of Google Play Store you need to [enable installing unknown apps.](https://developer.android.com/distribute/marketing-tools/alternative-distribution#unknown-sources)
+ 
+> If you are in place with no Internet connection, you can share the previously downloaded Mapeo APK from your mobile device with others via Bluetooth using third party tools such as [Bluetooth APK sender](https://play.google.com/store/apps/details?id=com.arabyfree.apk_app_share) or using your Mobile phone WiFi with [Easy Share : WiFi File Transfer](https://play.google.com/store/apps/details?id=com.idea.share&hl=en&gl=US)
+
 
 ## Install on PC
 


### PR DESCRIPTION
Adds a note about enabling third party installs. 

Provides simple alternative instructions for offline sideloading of APKs (Fixes #11)